### PR TITLE
[FEATURE] adding service catalog categories list

### DIFF
--- a/freshservice/client.go
+++ b/freshservice/client.go
@@ -116,3 +116,8 @@ func stripURLScheme(domain string) string {
 func (fs *Client) Tickets() TicketService {
 	return &TicketServiceClient{client: fs}
 }
+
+// ServiceCatalog is the interface between the HTTP client and the Freshservice service catalog related endpoints
+func (fs *Client) ServiceCatalog() ServiceCatalogService {
+	return &ServiceCatalogServiceClient{client: fs}
+}

--- a/freshservice/service_catalog.go
+++ b/freshservice/service_catalog.go
@@ -7,12 +7,16 @@ import (
 	"net/url"
 )
 
-const serviceCatalogItemURL = "/api/v2/service_catalog/items"
+const (
+	serviceCatalogItemURL     = "/api/v2/service_catalog/items"
+	serviceCatalogCategoryURL = "/api/v2/service_catalog/categories"
+)
 
 // ServiceCatalogService is an interface for interacting with
 // the service catalog endpoints of the Freshservice API
 type ServiceCatalogService interface {
 	List(context.Context, QueryFilter) ([]ServiceCatalogItemDetails, error)
+	Categories(context.Context) ([]ServiceCategory, error)
 	Get(context.Context, int) (*ServiceCatalogItemDetails, error)
 }
 
@@ -45,6 +49,27 @@ func (sc *ServiceCatalogServiceClient) List(ctx context.Context, filter QueryFil
 	}
 
 	return res.Items, nil
+}
+
+// Categories will list all service catalog item categories in freshservice
+func (sc *ServiceCatalogServiceClient) Categories(ctx context.Context) ([]ServiceCategory, error) {
+	url := &url.URL{
+		Scheme: "https",
+		Host:   sc.client.Domain,
+		Path:   serviceCatalogCategoryURL,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &ServiceCategories{}
+	if err := sc.client.makeRequest(req, res); err != nil {
+		return nil, err
+	}
+
+	return res.List, nil
 }
 
 // Get a specific service category item from Freshservice via the item's ID

--- a/freshservice/service_catalog_entity.go
+++ b/freshservice/service_catalog_entity.go
@@ -47,6 +47,21 @@ type ServiceCatalogItemDetails struct {
 	ChildItems             []interface{}     `json:"child_items"`
 }
 
+// ServiceCategories represents service catalog item categories in Freshservice
+type ServiceCategories struct {
+	List []ServiceCategory `json:"service_categories"`
+}
+
+// ServiceCategory represents a category assigned to a service catalog item in Freshservice
+type ServiceCategory struct {
+	Description string    `json:"description"`
+	ID          int       `json:"id"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Name        string    `json:"name"`
+	Position    int       `json:"position"`
+}
+
 // ServiceCatalogItemListFilterOptions are the available filter options
 // for a service catalog API list request
 type ServiceCatalogItemListFilterOptions struct {


### PR DESCRIPTION
## What does this PR do?

- Adds service catalog categories list method
- Adds `ServiceCategory` method to API client

## PR Checklist 

- [ ] The title & description contain a short meaningful summary of work completed
- [ ] Tests have been updated/created and are passing locally
- [ ] Related documentation and [CHANGELOG](https://github.com/CoreyGriffin/go-freshservice/blob/main/CHANGELOG.md) have been updated
- [ ] I've reviewed the [contributing](https://github.com/CoreyGriffin/go-freshservice/blob/main/CONTRIBUTING.md) documentation

## Related PRs or Issues

- https://github.com/CoreyGriffin/go-freshservice/pull/8
