### PR TITLE
[MISC] updating client to support delete request and pagination

### DIFF
--- a/examples/ticket_list.go
+++ b/examples/ticket_list.go
@@ -11,14 +11,14 @@ import (
 func main() {
 	APIKey := "testing-123"
 	ctx := context.Background()
-	api, err := fs.New(ctx, "example.com", APIKey, nil)
+	api, err := fs.New(ctx, "example.freshservice.com", APIKey, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// List all tickets
 	// https://example.com/api/v2/tickets
-	t, err := api.Tickets().List(ctx, nil)
+	t, np, err := api.Tickets().List(ctx, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -28,7 +28,18 @@ func main() {
 		tList = append(tList, fmt.Sprintf("\n%d - %d", tick.ID, tick.ResponderID))
 	}
 
-	fmt.Printf("All Tickets:\nCount: %d\nResults: %v\n", len(t), tList)
+	// example querying another page using the returned query parameter
+	if np != "" {
+		t, _, err := api.Tickets().List(ctx, &fs.TicketListOptions{PageQuery: np})
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, tick := range t {
+			tList = append(tList, fmt.Sprintf("\n%d - %d", tick.ID, tick.ResponderID))
+		}
+	}
+
+	fmt.Printf("All Tickets:\nCount: %d\nResults: %v\n", len(tList), tList)
 
 	// List tickets using a built in filer query and sort by
 	f := &fs.TicketListOptions{
@@ -42,7 +53,7 @@ func main() {
 
 	// https://example.com/api/v2/tickets?email=test-account@example.com&order_type=desc
 	ftList := []string{}
-	ft, err := api.Tickets().List(ctx, f)
+	ft, _, err := api.Tickets().List(ctx, f)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/freshservice/agent.go
+++ b/freshservice/agent.go
@@ -14,7 +14,7 @@ const agentURL = "/api/v2/agents"
 // AgentService is an interface for interacting with
 // the agent endpoints of the Freshservice API
 type AgentService interface {
-	List(context.Context, QueryFilter) ([]AgentDetails, error)
+	List(context.Context, QueryFilter) ([]AgentDetails, string, error)
 	Create(context.Context, *AgentDetails) (*AgentDetails, error)
 	Get(context.Context, int) (*AgentDetails, error)
 	Update(context.Context, int, *AgentDetails) (*AgentDetails, error)
@@ -30,7 +30,7 @@ type AgentServiceClient struct {
 }
 
 // List all freshservice agents
-func (as *AgentServiceClient) List(ctx context.Context, filter QueryFilter) ([]AgentDetails, error) {
+func (as *AgentServiceClient) List(ctx context.Context, filter QueryFilter) ([]AgentDetails, string, error) {
 	url := &url.URL{
 		Scheme: "https",
 		Host:   as.client.Domain,
@@ -43,15 +43,16 @@ func (as *AgentServiceClient) List(ctx context.Context, filter QueryFilter) ([]A
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	res := &Agents{}
-	if err := as.client.makeRequest(req, res); err != nil {
-		return nil, err
+	resp, err := as.client.makeRequest(req, res)
+	if err != nil {
+		return nil, "", err
 	}
 
-	return res.List, nil
+	return res.List, HasNextPage(resp), nil
 }
 
 // Get a specific Freshservice agent
@@ -68,7 +69,7 @@ func (as *AgentServiceClient) Get(ctx context.Context, id int) (*AgentDetails, e
 	}
 
 	res := &Agent{}
-	if err := as.client.makeRequest(req, res); err != nil {
+	if _, err := as.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 
@@ -96,7 +97,7 @@ func (as *AgentServiceClient) Create(ctx context.Context, ad *AgentDetails) (*Ag
 	}
 
 	res := &Agent{}
-	if err := as.client.makeRequest(req, res); err != nil {
+	if _, err := as.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 
@@ -124,7 +125,7 @@ func (as *AgentServiceClient) Update(ctx context.Context, id int, ad *AgentDetai
 	}
 
 	res := &Agent{}
-	if err := as.client.makeRequest(req, res); err != nil {
+	if _, err := as.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 
@@ -162,7 +163,7 @@ func (as *AgentServiceClient) Deactivate(ctx context.Context, id int) (*AgentDet
 	}
 
 	res := &Agent{}
-	if err := as.client.makeRequest(req, res); err != nil {
+	if _, err := as.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 
@@ -183,7 +184,7 @@ func (as *AgentServiceClient) Reactivate(ctx context.Context, id int) (*AgentDet
 	}
 
 	res := &Agent{}
-	if err := as.client.makeRequest(req, res); err != nil {
+	if _, err := as.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 
@@ -204,7 +205,7 @@ func (as *AgentServiceClient) ConvertToRequester(ctx context.Context, id int) (*
 	}
 
 	res := &Agent{}
-	if err := as.client.makeRequest(req, res); err != nil {
+	if _, err := as.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 

--- a/freshservice/announcement.go
+++ b/freshservice/announcement.go
@@ -44,7 +44,7 @@ func (a *AnnouncementServiceClient) List(ctx context.Context, filter QueryFilter
 	}
 
 	res := &Announcements{}
-	if err := a.client.makeRequest(req, res); err != nil {
+	if _, err := a.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 	return res.List, nil
@@ -64,7 +64,7 @@ func (a *AnnouncementServiceClient) Get(ctx context.Context, id int) (*Announcem
 	}
 
 	res := &Announcement{}
-	if err := a.client.makeRequest(req, res); err != nil {
+	if _, err := a.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 
@@ -92,7 +92,7 @@ func (a *AnnouncementServiceClient) Create(ctx context.Context, details *Announc
 	}
 
 	res := &Announcement{}
-	if err := a.client.makeRequest(req, res); err != nil {
+	if _, err := a.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 
@@ -120,7 +120,7 @@ func (a *AnnouncementServiceClient) Update(ctx context.Context, id int, details 
 	}
 
 	res := &Announcement{}
-	if err := a.client.makeRequest(req, res); err != nil {
+	if _, err := a.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 
@@ -140,7 +140,7 @@ func (a *AnnouncementServiceClient) Delete(ctx context.Context, id int) error {
 		return err
 	}
 
-	if err := a.client.makeRequest(req, nil); err != nil {
+	if _, err := a.client.makeRequest(req, nil); err != nil {
 		return err
 	}
 	return nil

--- a/freshservice/service_catalog.go
+++ b/freshservice/service_catalog.go
@@ -44,7 +44,7 @@ func (sc *ServiceCatalogServiceClient) List(ctx context.Context, filter QueryFil
 	}
 
 	res := &ServiceCatalog{}
-	if err := sc.client.makeRequest(req, res); err != nil {
+	if _, err := sc.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 
@@ -65,7 +65,7 @@ func (sc *ServiceCatalogServiceClient) Categories(ctx context.Context) ([]Servic
 	}
 
 	res := &ServiceCategories{}
-	if err := sc.client.makeRequest(req, res); err != nil {
+	if _, err := sc.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 
@@ -86,7 +86,7 @@ func (sc *ServiceCatalogServiceClient) Get(ctx context.Context, id int) (*Servic
 	}
 
 	res := &ServiceCatalogItem{}
-	if err := sc.client.makeRequest(req, res); err != nil {
+	if _, err := sc.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 

--- a/freshservice/ticket.go
+++ b/freshservice/ticket.go
@@ -14,12 +14,12 @@ const ticketURL = "/api/v2/tickets"
 // TicketService is an interface for interacting with
 // the ticket endpoints of the Freshservice API
 type TicketService interface {
-	List(context.Context, QueryFilter) ([]TicketDetails, error)
+	List(context.Context, QueryFilter) ([]TicketDetails, string, error)
 	Create(context.Context, *TicketDetails) (*TicketDetails, error)
 	CreateWithAttachment() (*Ticket, error)
 	Get(context.Context, int, QueryFilter) (*TicketDetails, error)
 	Update(context.Context, int, *TicketDetails) (*TicketDetails, error)
-	Delete() (*Ticket, error)
+	Delete(context.Context, int) error
 }
 
 // TicketServiceClient facilitates requests with the TicketService methods
@@ -27,12 +27,10 @@ type TicketServiceClient struct {
 	client *Client
 }
 
-// TODO: extract to private method to incorporate pagination using "link" header
-
 // List all Freshservice tickets
 // All the below requests are paginated to return only 30 tickets per page.
 // Append the parameter "page=[:page_no]" in the url to traverse through pages.
-func (t *TicketServiceClient) List(ctx context.Context, filter QueryFilter) ([]TicketDetails, error) {
+func (t *TicketServiceClient) List(ctx context.Context, filter QueryFilter) ([]TicketDetails, string, error) {
 	url := &url.URL{
 		Scheme: "https",
 		Host:   t.client.Domain,
@@ -45,15 +43,16 @@ func (t *TicketServiceClient) List(ctx context.Context, filter QueryFilter) ([]T
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	res := &Tickets{}
-	if err := t.client.makeRequest(req, res); err != nil {
-		return nil, err
+	resp, err := t.client.makeRequest(req, res)
+	if err != nil {
+		return nil, "", err
 	}
 
-	return res.List, nil
+	return res.List, HasNextPage(resp), nil
 }
 
 // Create a new Freshservice ticket
@@ -77,7 +76,7 @@ func (t *TicketServiceClient) Create(ctx context.Context, td *TicketDetails) (*T
 	}
 
 	res := &Ticket{}
-	if err := t.client.makeRequest(req, res); err != nil {
+	if _, err := t.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 
@@ -109,7 +108,7 @@ func (t *TicketServiceClient) Get(ctx context.Context, id int, filter QueryFilte
 	}
 
 	res := &Ticket{}
-	if err := t.client.makeRequest(req, res); err != nil {
+	if _, err := t.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 	return &res.Details, nil
@@ -136,13 +135,28 @@ func (t *TicketServiceClient) Update(ctx context.Context, id int, details *Ticke
 	}
 
 	res := &Ticket{}
-	if err := t.client.makeRequest(req, res); err != nil {
+	if _, err := t.client.makeRequest(req, res); err != nil {
 		return nil, err
 	}
 	return &res.Details, nil
 }
 
 // Delete Freshservice ticket
-func (t *TicketServiceClient) Delete() (*Ticket, error) {
-	return nil, nil
+func (t *TicketServiceClient) Delete(ctx context.Context, id int) error {
+	url := &url.URL{
+		Scheme: "https",
+		Host:   t.client.Domain,
+		Path:   fmt.Sprintf("%s/%d", ticketURL, id),
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	if _, err := t.client.makeRequest(req, nil); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/freshservice/ticket_entity.go
+++ b/freshservice/ticket_entity.go
@@ -137,9 +137,10 @@ type CustomFields map[string]interface{}
 // TicketListOptions holds the available options that can be
 // passed when requesting a list of Freshservice ticketsx
 type TicketListOptions struct {
-	FilterBy *TicketFilter
-	SortBy   *SortOptions
-	Embed    *TicketEmbedOptions
+	PageQuery string
+	FilterBy  *TicketFilter
+	SortBy    *SortOptions
+	Embed     *TicketEmbedOptions
 }
 
 // TicketEmbedOptions will optonally embed desired metadata in a ticket list response
@@ -172,6 +173,10 @@ type TicketFilter struct {
 // will return a new endpoint URL with query parameters attached
 func (opts *TicketListOptions) QueryString() string {
 	var qs []string
+
+	if opts.PageQuery != "" {
+		qs = append(qs, opts.PageQuery)
+	}
 
 	if opts.FilterBy != nil {
 		switch {

--- a/freshservice/util.go
+++ b/freshservice/util.go
@@ -1,5 +1,11 @@
 package freshservice
 
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
 // Int is a built in utility function that will return a *int
 func Int(i int) *int {
 	return &i
@@ -19,4 +25,32 @@ func StringInSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// HasNextPage will take in an http response and check
+// for the existence of the "link" header to determine whether or
+// not there is another page returning the next page's URL
+// <https://example.freshservice.com/api/v2/tickets?page=2>; rel="next"
+func HasNextPage(resp *http.Response) string {
+	link, ok := resp.Header["Link"]
+	if !ok {
+		return ""
+	}
+
+	// pull out raw url
+	u := strings.Split(link[0], ";")[0]
+	// drop the carrots < >
+	u = u[1 : len(u)-1]
+
+	return ParseNextPage(u)
+}
+
+// ParseNextPage will return the next page parameter parsed
+// out of a raw URL string's "page=[:page_no]" parameter
+func ParseNextPage(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.RawQuery
 }


### PR DESCRIPTION
## What does this PR do?

- Updates client's `makeRequest` method to support `204` response codes with no response
- Updates client signature to return the http response so the headers can be parsed to support pagination
- Adds a few util methods to pull out the `page=x` query parameter from the `link` header

## PR Checklist 

- [ ] The title & description contain a short meaningful summary of work completed
- [ ] Tests have been updated/created and are passing locally
- [ ] Related documentation and [CHANGELOG](https://github.com/CoreyGriffin/go-freshservice/blob/main/CHANGELOG.md) have been updated
- [ ] I've reviewed the [contributing](https://github.com/CoreyGriffin/go-freshservice/blob/main/CONTRIBUTING.md) documentation

## Related PRs or Issues

- [link](<>)
