### PR TITLE
[FEATURE] adding freshservice business hour methods

### DIFF
--- a/freshservice/business_hours.go
+++ b/freshservice/business_hours.go
@@ -1,0 +1,64 @@
+package freshservice
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const businessHoursURL = "/api/v2/business_hours"
+
+// BusinessHoursService is an interface for interacting with
+// the business hours endpoints of the Freshservice API
+type BusinessHoursService interface {
+	List(context.Context) ([]BusinessHoursConfig, error)
+	Get(context.Context, int) (*BusinessHoursDetails, error)
+}
+
+// BusinessHoursServiceClient facilitates requests with the AnnouncementService methods
+type BusinessHoursServiceClient struct {
+	client *Client
+}
+
+// List all business hours configured in Freshservice
+func (c *BusinessHoursServiceClient) List(ctx context.Context) ([]BusinessHoursConfig, error) {
+	url := &url.URL{
+		Scheme: "https",
+		Host:   c.client.Domain,
+		Path:   businessHoursURL,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &BusinessHours{}
+	if _, err := c.client.makeRequest(req, res); err != nil {
+		return nil, err
+	}
+
+	return res.List, nil
+}
+
+// Get a details for a specific business hour configuration in Freshservice
+func (c *BusinessHoursServiceClient) Get(ctx context.Context, id int) (*BusinessHoursDetails, error) {
+	url := &url.URL{
+		Scheme: "https",
+		Host:   c.client.Domain,
+		Path:   fmt.Sprintf("%s/%d", businessHoursURL, id),
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &BusinessHoursConfig{}
+	if _, err := c.client.makeRequest(req, res); err != nil {
+		return nil, err
+	}
+
+	return &res.Details, nil
+}

--- a/freshservice/business_hours_entity.go
+++ b/freshservice/business_hours_entity.go
@@ -1,0 +1,47 @@
+package freshservice
+
+import "time"
+
+//BusinessHours holds the Business Hours Configurations in Freshservice
+type BusinessHours struct {
+	List []BusinessHoursConfig `json:"business_hours"`
+}
+
+// BusinessHoursConfig holds a configuration for business hours in Freshservice
+type BusinessHoursConfig struct {
+	Details BusinessHoursDetails `json:"business_hours"`
+}
+
+// BusinessHoursDetails holds a configuration for business hours in Freshservice
+type BusinessHoursDetails struct {
+	ID               int              `json:"id"`
+	CreatedAt        time.Time        `json:"created_at"`
+	UpdatedAt        time.Time        `json:"updated_at"`
+	Name             string           `json:"name"`
+	Description      string           `json:"description"`
+	IsDefault        bool             `json:"is_default"`
+	TimeZone         string           `json:"time_zone"`
+	ServiceDeskHours ServiceDeskHours `json:"service_desk_hours"`
+	ListOfHolidays   []WorkdayHoliday `json:"list_of_holidays"`
+}
+
+// ServiceDeskHours contains the time at which the workday begins and ends for the seven days of the week.
+type ServiceDeskHours struct {
+	Monday    WorkdayHours `json:"monday"`
+	Tuesday   WorkdayHours `json:"tuesday"`
+	Wednesday WorkdayHours `json:"wednesday"`
+	Thursday  WorkdayHours `json:"thursday"`
+	Friday    WorkdayHours `json:"friday"`
+}
+
+// WorkdayHours contains the time at which the workday begins and ends
+type WorkdayHours struct {
+	BeginningOfWorkday string `json:"beginning_of_workday"`
+	EndOfWorkday       string `json:"end_of_workday"`
+}
+
+// WorkdayHoliday holds a configured holiday for the year. Dates are in ISO --MM-DD format.
+type WorkdayHoliday struct {
+	HolidayDate string `json:"holiday_date"`
+	HolidayName string `json:"holiday_name"`
+}

--- a/freshservice/client.go
+++ b/freshservice/client.go
@@ -132,3 +132,8 @@ func (fs *Client) Announcements() AnnouncementService {
 func (fs *Client) Agents() AgentService {
 	return &AgentServiceClient{client: fs}
 }
+
+// BusinessHours is the interface between the HTTP client and the Freshservice business hours related endpoints
+func (fs *Client) BusinessHours() BusinessHoursService {
+	return &BusinessHoursServiceClient{client: fs}
+}


### PR DESCRIPTION
## What does this PR do?

- adds the [`business hours`](https://api.freshservice.com/v2/#view_a_business_hour) API methods

## PR Checklist 

- [ ] The title & description contain a short meaningful summary of work completed
- [ ] Tests have been updated/created and are passing locally
- [ ] Related documentation and [CHANGELOG](https://github.com/CoreyGriffin/go-freshservice/blob/main/CHANGELOG.md) have been updated
- [ ] I've reviewed the [contributing](https://github.com/CoreyGriffin/go-freshservice/blob/main/CONTRIBUTING.md) documentation

## Related PRs or Issues

- [link](<>)
